### PR TITLE
TF-107: Add ClientInfo method to tools package

### DIFF
--- a/tools/service.go
+++ b/tools/service.go
@@ -41,3 +41,13 @@ func (s *Service) Whoami(ctx context.Context) (string, error) {
 
 	return fmt.Sprintf("%s %d", result.Email, result.Client), nil
 }
+
+func (s *Service) ClientInfo(ctx context.Context) (*ClientInfoResponse, error) {
+	var result ClientInfoResponse
+
+	if err := s.r.Request(ctx, http.MethodGet, "/cdn/clients/me", nil, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/tools/service_test.go
+++ b/tools/service_test.go
@@ -99,3 +99,58 @@ func TestService_Purge(t *testing.T) {
 		})
 	}
 }
+
+func TestService_ClientInfo(t *testing.T) {
+	tests := []struct {
+		name             string
+		response         ClientInfoResponse
+		expectedResponse ClientInfoResponse
+	}{
+		{
+			name: "Get client info",
+			response: ClientInfoResponse{
+				ID:    123,
+				Cname: "cl-123.edgecdn.ru",
+			},
+			expectedResponse: ClientInfoResponse{
+				ID:    123,
+				Cname: "cl-123.edgecdn.ru",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/cdn/clients/me" || r.Method != http.MethodGet {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+
+				if err := json.NewEncoder(w).Encode(tt.response); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"message": fmt.Sprintf("invalid response %s", err.Error())})
+					return
+				}
+			})
+
+			ts := httptest.NewServer(mockHandler)
+			defer ts.Close()
+
+			service := NewService(provider.NewClient(ts.URL))
+
+			ctx := context.Background()
+
+			response, err := service.ClientInfo(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(response, &tt.expectedResponse) {
+				t.Errorf("expected %+v, got %+v", &tt.expectedResponse, response)
+			}
+		})
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,6 +5,7 @@ import "context"
 type ResourceToolsService interface {
 	Purge(ctx context.Context, id int64, req *PurgeRequest) (*PurgeResponse, error)
 	Whoami(ctx context.Context) (string, error)
+	ClientInfo(ctx context.Context) (*ClientInfoResponse, error)
 }
 
 type PurgeRequest struct {
@@ -20,4 +21,9 @@ type WhoamiResponse struct {
 	Client int64  `json:"client"`
 	Email  string `json:"email"`
 	Name   string `json:"name"`
+}
+
+type ClientInfoResponse struct {
+	ID    int64  `json:"id"`
+	Cname string `json:"cname"`
 }


### PR DESCRIPTION
Add `ClientInfo` method to `tools.ResourceToolsService` that
retrieves CDN client information (CNAME target, client ID) via
`GET /cdn/clients/me`.