### PR TITLE
feat(TF-115) [lecert] support cert_type in CDN issue flow

### DIFF
--- a/lecerts/lecerts.go
+++ b/lecerts/lecerts.go
@@ -11,6 +11,7 @@ type LECertService interface {
 	UpdateLECert(ctx context.Context, resourceID int64) error
 	DeleteLECert(ctx context.Context, resourceID int64, force bool) error
 	CancelLECert(ctx context.Context, resourceID int64, active bool) error
+	IssueLECert(ctx context.Context, resourceID int64, req *IssueRequest) error
 }
 
 type LECertIssueService interface {

--- a/lecerts/lecerts.go
+++ b/lecerts/lecerts.go
@@ -2,6 +2,7 @@ package lecerts
 
 import (
 	"context"
+	"encoding/json"
 )
 
 type LECertService interface {
@@ -12,6 +13,21 @@ type LECertService interface {
 	CancelLECert(ctx context.Context, resourceID int64, active bool) error
 }
 
+type LECertIssueService interface {
+	IssueLECert(ctx context.Context, resourceID int64, req *IssueRequest) error
+}
+
+type CertType string
+
+const (
+	CertTypeLE   CertType = "LE"
+	CertTypeMDDC CertType = "MDDC"
+)
+
+type IssueRequest struct {
+	CertType CertType `json:"cert_type,omitempty"`
+}
+
 type LECertStatus struct {
 	ID       int              `json:"ssl_id"`
 	Statuses []LEStatusDetail `json:"statuses"`
@@ -19,6 +35,7 @@ type LECertStatus struct {
 	Finished *string          `json:"finished"`
 	Active   bool             `json:"active"`
 	Resource int              `json:"resource"`
+	CertType CertType         `json:"cert_type,omitempty"`
 }
 
 type LEStatusDetail struct {
@@ -26,4 +43,24 @@ type LEStatusDetail struct {
 	Error   string `json:"error"`
 	Details string `json:"details"`
 	Created string `json:"created"`
+}
+
+func (s *LECertStatus) UnmarshalJSON(data []byte) error {
+	type alias LECertStatus
+
+	aux := struct {
+		alias
+		CertTypeLegacy CertType `json:"cet_type"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*s = LECertStatus(aux.alias)
+	if s.CertType == "" {
+		s.CertType = aux.CertTypeLegacy
+	}
+
+	return nil
 }

--- a/lecerts/service.go
+++ b/lecerts/service.go
@@ -13,6 +13,9 @@ type Service struct {
 	r edgecenter.Requester
 }
 
+var _ LECertService = (*Service)(nil)
+var _ LECertIssueService = (*Service)(nil)
+
 func NewService(r edgecenter.Requester) *Service {
 	return &Service{r: r}
 }
@@ -32,11 +35,20 @@ func (s *Service) GetLECert(ctx context.Context, resourceID int64) (*LECertStatu
 }
 
 func (s *Service) CreateLECert(ctx context.Context, resourceID int64) error {
+	return s.IssueLECert(ctx, resourceID, nil)
+}
+
+func (s *Service) IssueLECert(ctx context.Context, resourceID int64, req *IssueRequest) error {
 	u := url.URL{
 		Path: fmt.Sprintf("/cdn/resources/%d/ssl/le/issue", resourceID),
 	}
 
-	if err := s.r.Request(ctx, http.MethodPost, u.String(), nil, nil); err != nil {
+	var body interface{}
+	if req != nil && req.CertType != "" {
+		body = req
+	}
+
+	if err := s.r.Request(ctx, http.MethodPost, u.String(), body, nil); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
 

--- a/lecerts/service_test.go
+++ b/lecerts/service_test.go
@@ -31,6 +31,7 @@ func TestLECertService_GetLECert(t *testing.T) {
 		Active:   true,
 		Resource: 100,
 		Started:  "2024-01-01T00:00:00Z",
+		CertType: CertTypeLE,
 		Statuses: []LEStatusDetail{
 			{Status: "done", Created: "2024-01-01T00:00:00Z"},
 		},
@@ -46,12 +47,69 @@ func TestLECertService_GetLECert(t *testing.T) {
 	assert.Equal(t, &expected, result)
 }
 
+func TestLECertService_GetLECert_LegacyCertTypeKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/cdn/resources/100/ssl/le/status", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ssl_id":   1,
+			"statuses": []map[string]string{},
+			"started":  "2024-01-01T00:00:00Z",
+			"active":   true,
+			"resource": 100,
+			"cet_type": "MDDC",
+		})
+	}))
+	defer ts.Close()
+
+	service := NewService(provider.NewClient(ts.URL))
+	result, err := service.GetLECert(context.Background(), 100)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, CertTypeMDDC, result.CertType)
+}
+
 func TestLECertService_CreateLECert(t *testing.T) {
-	ts := setupMockServer(t, http.MethodPost, "/cdn/resources/100/ssl/le/issue", http.StatusOK, nil)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/cdn/resources/100/ssl/le/issue", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Empty(t, body)
+
+		w.WriteHeader(http.StatusOK)
+	}))
 	defer ts.Close()
 
 	service := NewService(provider.NewClient(ts.URL))
 	err := service.CreateLECert(context.Background(), 100)
+
+	require.NoError(t, err)
+}
+
+func TestLECertService_IssueLECert(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/cdn/resources/100/ssl/le/issue", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var payload IssueRequest
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, CertTypeMDDC, payload.CertType)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	service := NewService(provider.NewClient(ts.URL))
+	err := service.IssueLECert(context.Background(), 100, &IssueRequest{
+		CertType: CertTypeMDDC,
+	})
 
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Adds backward-compatible `cert_type` support to the CDN lecert issue flow and status parsing.